### PR TITLE
Fix behavior of Exkanji.Mecab.prepare/1

### DIFF
--- a/lib/exkanji/mecab.ex
+++ b/lib/exkanji/mecab.ex
@@ -52,7 +52,7 @@ defmodule Exkanji.Mecab do
     |> to_string
     |> String.codepoints
     |> Enum.map(fn(p) ->
-      if Enum.member?(["'", "\""], p), do: ~s(\\#{p}), else: p
+      if Enum.member?(["'", "\"", "&", ";", "|", "<", ">", "(", ")", "`"], p), do: ~s(\\#{p}), else: p
     end)
     |> Enum.join
     |> to_char_list


### PR DESCRIPTION
Currently, Mecab.parse raises MatchError.

``` elixir
iex(1)> Exkanji.parse("エモい&エモい")
** (MatchError) no match of right hand side value: ["エモい"]
             lib/exkanji/mecab.ex:32: Exkanji.Mecab.parse_line/2
    (elixir) lib/enum.ex:758: anonymous fn/4 in Enum.filter_map/3
    (elixir) lib/enum.ex:1473: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir) lib/enum.ex:758: Enum.filter_map/3
             lib/exkanji/mecab.ex:20: Exkanji.Mecab.parse/2
```
